### PR TITLE
[FE] 🔧update : 로그인 페이지 이동 관련 history 관리 로직 구현

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
+import getGlobalState from '../util/authorization/getGlobalState';
 import logo from '../assets/logo.svg';
 import search from '../assets/icon_search.svg';
 import mypage from '../assets/icon_mypage.svg';
@@ -17,11 +18,11 @@ const HeaderContainer = styled.header`
   background: var(--white);
   border-bottom: 1px solid var(--gray100);
   z-index: 100;
-  
+
   display: flex;
   align-items: center;
   justify-content: space-between;
-  
+
   img {
     height: 28px;
     margin-top: 6px;
@@ -38,11 +39,13 @@ const IconContainer = styled.div`
 `;
 
 function Header() {
+  const { isLogin } = getGlobalState();
   const navigate = useNavigate();
+  const linkTo = isLogin ? '/home' : '/';
 
   return (
     <HeaderContainer>
-      <Link to='/'>
+      <Link to={linkTo}>
         <img src={logo} alt='소모전 로고' />
       </Link>
       <IconContainer>

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import getGlobalState from '../../../util/authorization/getGlobalState';
 import { getFetch } from '../../../util/api';
@@ -68,9 +68,6 @@ function ClubIntro() {
 
   const { id } = useParams();
   const navigate = useNavigate();
-  const goToPath = (path: string) => {
-    navigate(path);
-  };
 
   const [clubInfo, setClubInfo] = useState<ClubData>();
   useEffect(() => {
@@ -108,11 +105,15 @@ function ClubIntro() {
     setShowModal((current) => !current);
   };
 
-  // TODO : 로그인 여부에 따른 분기 처리 지정 (history 관리 필요)
+  // * 로그인 여부에 따른 분기 처리
+  const { pathname } = useLocation();
+  const RETURN_URL_PARAM = 'returnUrl';
   const handleJoinRequest = () => {
-    handleModal();
-    // if (isLogin) handleModal();
-    // else navigate('/login');
+    if (isLogin) {
+      handleModal();
+    } else {
+      navigate(`/login?${RETURN_URL_PARAM}=${encodeURIComponent(pathname)}`, { replace: true });
+    }
   };
 
   return (
@@ -154,7 +155,7 @@ function ClubIntro() {
             </div>
             {/* TODO: 권한 확인 후 클럽장에게만 렌더링 */}
             <div className='club-setting-btn-area'>
-              <S_SelectButton width='auto' onClick={() => goToPath(`/club/${id}/setting`)}>
+              <S_SelectButton width='auto' onClick={() => navigate(`/club/${id}/setting`)}>
                 소모임 설정
               </S_SelectButton>
             </div>

--- a/client/src/pages/user/Login.tsx
+++ b/client/src/pages/user/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { checkEmail, checkPassword } from '../../util/authorization/checkPassword';
 import alertPreparingService from '../../util/alertPreparingService';
@@ -47,6 +47,8 @@ export const S_InstructionWrapper = styled.div`
 
 function Login() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnUrl = searchParams.get('returnUrl'); // 바로 디코딩해줌. query string이 없으면 null
 
   const [inputs, setInputs] = useState({
     email: '',
@@ -88,11 +90,12 @@ function Login() {
 
     if (!isValidEmail || !isValidPassword) return;
 
-    // 서버에 로그인 post 요청 및 전역 상태 설정
+    // * 서버에 로그인 post 요청 및 전역 상태 설정
     const res = await handleLogin(inputs);
 
     if (res) {
-      navigate('/home');
+      if (returnUrl) navigate(returnUrl, { replace: true });
+      else navigate('/home');
     }
   };
   // console.log(inputs);


### PR DESCRIPTION
## 개요
* 요구사항 ID : 
* Issue No. : #149 

## 작업 카테고리
- [ ] Feature 
- [x] Update
- [ ] Fix
- [ ] Refactor
- [ ] Test

## 핵심 사항
* 로그인하지 않은 방문자가 소모임 가입신청 클릭시 로그인 페이지로 갔다 되돌아오는 과정의 history 관리 
* 공통 헤더의 소모전 로고 클릭시 로그인 여부에 따라 홈 또는 인트로 페이지로 이동하는 linkTo 함수 작성

https://user-images.githubusercontent.com/115610668/227126889-236b399f-0502-45cc-baff-51ff8036cbaf.mov




### 기타 참고 사항
* 남은 부분: 카카오톡 로그인 후처리
