### PR TITLE
[FE]🐛 fix: 모든경기일정조회/PENDING유저만나오게 리렌더링처리

### DIFF
--- a/client/src/components/match/ScheduleCard.tsx
+++ b/client/src/components/match/ScheduleCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { S_SelectButton } from '../UI/S_Button';
 import { S_Label, S_Text } from '../UI/S_Text';
@@ -23,10 +23,10 @@ interface ScheduleCardProps {
   time?: string;
   placeName?: string;
   scheduleId: number;
+  clubId: number;
 }
 function ScheduleCard(props: ScheduleCardProps) {
   const navigate = useNavigate();
-  const { id } = useParams();
   const [clickedButton, setClickedButton] = useState<string | null>('');
   const buttonHandler = (e: React.MouseEvent<HTMLElement>) => {
     setClickedButton(e.currentTarget.getAttribute('name'));
@@ -34,7 +34,7 @@ function ScheduleCard(props: ScheduleCardProps) {
   return (
     <>
       <hr style={{ margin: '20px 0' }} />
-      <S_CardContainer onClick={() => navigate(`/club/${id}/match/${props.scheduleId}`)}>
+      <S_CardContainer onClick={() => navigate(`/club/${props.clubId}/match/${props.scheduleId}`)}>
         <S_Information>
           <S_Text>{`${props.date} ${props.time}`}</S_Text>
           <S_Label>{props.placeName}</S_Label>

--- a/client/src/components/setting/MemberWaitingCard.tsx
+++ b/client/src/components/setting/MemberWaitingCard.tsx
@@ -32,6 +32,7 @@ const S_ButtonWrapper = styled.div`
 interface MemberWaitingCardProps {
   member: WaitingUser;
   setIsUpdated: React.Dispatch<React.SetStateAction<boolean>>;
+  isUpdated: boolean;
 }
 
 function MemberWaitingCard(props: MemberWaitingCardProps) {
@@ -42,7 +43,7 @@ function MemberWaitingCard(props: MemberWaitingCardProps) {
         joinStatus: 'CONFIRMED'
       })
       .then(() => {
-        props.setIsUpdated(true);
+        props.setIsUpdated(!props.isUpdated);
       });
   };
 

--- a/client/src/pages/club/match/_pastMatch.tsx
+++ b/client/src/pages/club/match/_pastMatch.tsx
@@ -19,6 +19,7 @@ function PastMatch(props: PastMatchProps) {
           return (
             <ScheduleCard
               key={el.scheduleId}
+              clubId={el.clubId}
               scheduleId={el.scheduleId}
               date={el.date}
               time={el.time}

--- a/client/src/pages/club/match/_scheduledMatch.tsx
+++ b/client/src/pages/club/match/_scheduledMatch.tsx
@@ -19,6 +19,7 @@ function ScheduledMatch(props: ScheduledMatchProps) {
           return (
             <ScheduleCard
               key={el.scheduleId}
+              clubId={el.clubId}
               scheduleId={el.scheduleId}
               date={el.date}
               time={el.time}

--- a/client/src/pages/club/setting/_waitingMember.tsx
+++ b/client/src/pages/club/setting/_waitingMember.tsx
@@ -33,7 +33,12 @@ function WaitingMember() {
       {data
         ?.filter((ele) => ele.joinStatus === 'PENDING')
         .map((el) => (
-          <MemberWaitingCard key={el.userInfo.userId} member={el} setIsUpdated={setIsUpdated} />
+          <MemberWaitingCard
+            key={el.userInfo.userId}
+            member={el}
+            setIsUpdated={setIsUpdated}
+            isUpdated={isUpdated}
+          />
         ))}
     </>
   );


### PR DESCRIPTION
## 개요
* 요구사항 ID : 
* Issue No. : 

## 작업 카테고리
- [ ] Feature 
- [ ] Update
- [x] Fix
- [ ] Refactor
- [ ] Test


### 수정 내용 (fix의 경우)
* 변경 부분: 모든경기일정 조회를 위한 clubId 추가, 가입승인 처리시 pending 상태 유저만 보이게 리렌더링 처리
