### PR TITLE
[FE] ✨ feat : 소모임 수정 페이지 patch api 로직 구현

### DIFF
--- a/client/src/components/MyPage/ClubListSetting.tsx
+++ b/client/src/components/MyPage/ClubListSetting.tsx
@@ -14,7 +14,7 @@ function ClubListSetting() {
           key={el.clubId}
           clubId={el.clubId}
           clubName={el.clubName}
-          profileImage={el.profileImage}
+          clubImageUrl={el.profileImage}
           content={el.content}
           local={el.local}
           categoryName={el.categoryName}

--- a/client/src/components/home/ClubList.tsx
+++ b/client/src/components/home/ClubList.tsx
@@ -47,7 +47,7 @@ const S_Hidden = styled.div`
 function ClubList({
   clubId,
   clubName,
-  profileImage,
+  clubImageUrl,
   content,
   local,
   categoryName,
@@ -56,7 +56,7 @@ function ClubList({
 }: ClubData) {
   return (
     <S_ClubBox>
-      <S_ImgBox img={profileImage} />
+      <S_ImgBox img={clubImageUrl} />
       <Link to={`/club/${clubId}`}>
         <S_ContentsBox>
           <S_TitleBox>

--- a/client/src/components/home/MainContents.tsx
+++ b/client/src/components/home/MainContents.tsx
@@ -76,7 +76,7 @@ function MainContents() {
           key={el.clubId}
           clubId={el.clubId}
           clubName={el.clubName}
-          profileImage={el.profileImage}
+          clubImageUrl={el.profileImage}
           content={el.content}
           local={el.local}
           categoryName={el.categoryName}

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -32,7 +32,7 @@ function EditClub() {
     isPrivate: false
   });
 
-  const { categoryName } = clubInfo || {};
+  const { categoryName, local: prevLocal } = clubInfo || {};
 
   const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
   useEffect(() => {
@@ -56,8 +56,8 @@ function EditClub() {
       });
     }
   }, [clubInfo]);
-  console.log('서버에서 보내준 소모임 정보:', clubInfo);
-  console.log('input value:', inputs);
+  // console.log('서버에서 보내준 소모임 정보:', clubInfo);
+  // console.log('input value:', inputs);
 
   // !TODO: profileImage 사진 어떻게 보낼지
 
@@ -118,7 +118,7 @@ function EditClub() {
             <label htmlFor='categoryName'>
               <S_Label>카테고리</S_Label>
             </label>
-            <S_Description>소모임 종류는 한번 입력하시면 변경할 수 없습니다.</S_Description>
+            <S_Description>소모임 종류는 처음 모임을 만든 다음에는 변경할 수 없어요.</S_Description>
             <S_Input
               id='categoryName'
               name='categoryName'
@@ -129,7 +129,7 @@ function EditClub() {
             />
           </div>
           {/* //TODO: <option selected> */}
-          <CreateLocal inputValue={localValue} setInputValue={setLocalValue} />
+          <CreateLocal prevData={prevLocal} inputValue={localValue} setInputValue={setLocalValue} />
           {/* //TODO: prevTags props로 보내기 */}
           <CreateTag tags={tags} setTags={setTags} />
           {/* 사진 등록 영역 */}

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { getFetch } from '../../../util/api';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getFetch, patchFetch } from '../../../util/api';
 import CreateLocal from './_createLocal';
 import CreateTag from './_createTag';
 import S_Container from '../../../components/UI/S_Container';
@@ -21,9 +21,11 @@ export interface EditClubDataType {
 }
 
 function EditClub() {
+  const navigate = useNavigate();
   const { id: clubId } = useParams();
-  const [clubInfo, setClubInfo] = useState<ClubData>();
+  const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
 
+  const [clubInfo, setClubInfo] = useState<ClubData>();
   const [inputs, setInputs] = useState<EditClubDataType>({
     clubName: '',
     content: '',
@@ -31,40 +33,41 @@ function EditClub() {
     tagName: [],
     isPrivate: false
   });
+  const { categoryName, local: prevLocal, secret } = clubInfo || {};
+  const { clubName, content } = inputs || {};
 
-  const { categoryName, local: prevLocal } = clubInfo || {};
-
-  const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
   useEffect(() => {
     const getClubInfo = async () => {
       const res = await getFetch(URL);
-      setClubInfo(res.data);
+      const clubInfo: ClubData = res.data;
+      setClubInfo(clubInfo);
+
+      // * 기존 소모임 정보를 input 초기값으로 세팅
+      const { local: prevLocal, tagResponseDtos } = clubInfo || {};
+      const prevTags = tagResponseDtos?.map((tag) => tag.tagName) || [];
+      setTags(prevTags);
+      setLocalValue(prevLocal);
+
+      if (clubInfo) {
+        setInputs({
+          ...inputs,
+          clubName: clubInfo.clubName,
+          content: clubInfo.content,
+          local: clubInfo.local,
+          tagName: clubInfo.tagResponseDtos.map((tag) => tag.tagName),
+
+          // TODO: types > index.ts에서 secret 필드 ? 빠진거 확인하고 || false 삭제
+          // !BUG : 비공개 소모임(secret: true) 생성해도 서버에서 전부 secret: false 로 처리되고 있음
+          isPrivate: clubInfo.secret || false
+        });
+      }
     };
     getClubInfo();
   }, []);
 
-  useEffect(() => {
-    if (clubInfo) {
-      setInputs({
-        ...inputs,
-        clubName: clubInfo.clubName,
-        content: clubInfo.content,
-        local: clubInfo.local,
-        tagName: clubInfo.tagResponseDtos.map((tag) => tag.tagName),
-        // TODO: secret 필드 바뀐거 확인하고  || false 삭제
-        isPrivate: clubInfo.secret || false
-      });
-    }
-  }, [clubInfo]);
-  // console.log('서버에서 보내준 소모임 정보:', clubInfo);
-  // console.log('input value:', inputs);
-
-  // !TODO: profileImage 사진 어떻게 보낼지
-
-  const { clubName, content, local, tagName, isPrivate } = inputs || {};
+  // !TODO: profileImage patch 요청 어떻게 보낼지 BE와 방식 논의 필요
 
   const [tags, setTags] = useState<string[]>([]);
-  const [categoryValue, setCategoryValue] = useState('');
   const [localValue, setLocalValue] = useState('');
 
   const onChange = (
@@ -74,9 +77,18 @@ function EditClub() {
     setInputs({ ...inputs, [name]: name === 'isPrivate' ? value === 'true' : value });
   };
 
-  const onSubmit = () => {
-    console.log('제출');
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
+    const updateData = {
+      ...inputs,
+      tagName: tags,
+      local: localValue
+    };
+
+    // console.log(updateData);
+    const res = await patchFetch(URL, updateData);
+    if (res) navigate(`/club/${clubId}`);
   };
 
   return (
@@ -93,7 +105,6 @@ function EditClub() {
               name='clubName'
               type='text'
               maxLength={16}
-              defaultValue={clubInfo?.clubName}
               value={clubName}
               onChange={onChange}
               width='96%'
@@ -123,41 +134,62 @@ function EditClub() {
               id='categoryName'
               name='categoryName'
               type='text'
-              defaultValue={clubInfo?.categoryName}
+              defaultValue={categoryName}
               disabled
               width='96%'
             />
           </div>
-          {/* //TODO: <option selected> */}
           <CreateLocal prevData={prevLocal} inputValue={localValue} setInputValue={setLocalValue} />
-          {/* //TODO: prevTags props로 보내기 */}
           <CreateTag tags={tags} setTags={setTags} />
-          {/* 사진 등록 영역 */}
+
+          {/* //TODO: 사진 등록 영역 */}
           <S_Label>사진 등록</S_Label>
+
           <fieldset className='isPrivate'>
             <div>
               <S_Label>공개여부 *</S_Label>
             </div>
             <S_RadioWrapper>
               <div className='partition'>
-                <S_Input
-                  type='radio'
-                  id='public'
-                  name='isPrivate'
-                  value='false'
-                  onChange={onChange}
-                  defaultChecked
-                />
+                {secret ? (
+                  <S_Input
+                    type='radio'
+                    id='private'
+                    name='isPrivate'
+                    value='true'
+                    onChange={onChange}
+                  />
+                ) : (
+                  <S_Input
+                    type='radio'
+                    id='private'
+                    name='isPrivate'
+                    value='true'
+                    onChange={onChange}
+                    defaultChecked
+                  />
+                )}
                 <label htmlFor='public'>공개</label>
               </div>
               <div className='partition'>
-                <S_Input
-                  type='radio'
-                  id='private'
-                  name='isPrivate'
-                  value='true'
-                  onChange={onChange}
-                />
+                {secret ? (
+                  <S_Input
+                    type='radio'
+                    id='private'
+                    name='isPrivate'
+                    value='true'
+                    onChange={onChange}
+                    defaultChecked
+                  />
+                ) : (
+                  <S_Input
+                    type='radio'
+                    id='private'
+                    name='isPrivate'
+                    value='true'
+                    onChange={onChange}
+                  />
+                )}
                 <label htmlFor='private'>비공개</label>
               </div>
             </S_RadioWrapper>

--- a/client/src/pages/club/club/_createCategory.tsx
+++ b/client/src/pages/club/club/_createCategory.tsx
@@ -8,7 +8,7 @@ export interface HandleDropDownClick {
   (option: string): void;
 }
 
-export interface CreateCategoryAndLocalProps {
+export interface CreateCategoryProps {
   inputValue: string;
   setInputValue: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -16,7 +16,7 @@ export interface CreateCategoryAndLocalProps {
 interface CategoryListDataType {
   categoryName: string;
 }
-function CreateCategory({ inputValue, setInputValue }: CreateCategoryAndLocalProps) {
+function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
   const [categories, setCategories] = useState<string[]>();
   useEffect(() => {
     const GET_URL = `${process.env.REACT_APP_URL}/categories`;

--- a/client/src/pages/club/club/_createLocal.tsx
+++ b/client/src/pages/club/club/_createLocal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { DIVISIONS_DATA } from './divisions';
-import { CreateCategoryAndLocalProps } from './_createCategory';
+import { CreateCategoryProps } from './_createCategory';
 import { S_Label } from '../../../components/UI/S_Text';
 import { S_Select } from '../../../components/UI/S_Select';
 
@@ -15,7 +15,11 @@ interface DivisionType {
   districts: DistrictType[];
 }
 
-function CreateLocal({ inputValue, setInputValue }: CreateCategoryAndLocalProps) {
+interface CreateLocalProps extends CreateCategoryProps {
+  prevData?: string;
+}
+
+function CreateLocal({ inputValue, setInputValue, prevData }: CreateLocalProps) {
   // division: 지역 1단계 (광역시/도)
   // district: 지역 2단계 (시/군/구)
   const [divisionSelectValue, setDivisionSelectValue] = useState('');
@@ -56,6 +60,26 @@ function CreateLocal({ inputValue, setInputValue }: CreateCategoryAndLocalProps)
     }
   };
 
+  // * EditClub 컴포넌트를 위한 기존 local 정보 핸들링
+  const [prevLocal1, prevLocal2] = prevData?.split(' ') || [];
+  const [prevDivisionCode, setPrevDivisionCode] = useState('');
+  const [prevDistrictCode, setPrevDistrictCode] = useState('');
+
+  useEffect(() => {
+    const prevLocal1Code = DIVISIONS_DATA.find((d) => d.name === prevLocal1)?.code.slice(0, 2);
+    if (prevLocal1Code) setPrevDivisionCode(prevLocal1Code);
+
+    const prevLocal2Code = DIVISIONS_DATA.find((d) => d.name === prevLocal1)?.districts.find(
+      (d) => d.name === prevLocal2
+    )?.code;
+    if (prevLocal2Code) setPrevDistrictCode(prevLocal2Code);
+  });
+
+  useEffect(() => {
+    if (prevDivisionCode) setDivisionSelectValue(prevDivisionCode);
+    if (prevDistrictCode) setDistrictSelectValue(prevDistrictCode);
+  }, [prevDivisionCode, prevDistrictCode]);
+
   return (
     <div>
       <label htmlFor='local'>
@@ -63,20 +87,32 @@ function CreateLocal({ inputValue, setInputValue }: CreateCategoryAndLocalProps)
       </label>
       <S_Select id='local' name='division' onChange={handleSelectChange}>
         <option>선택</option>
-        {divisionList.map((d) => (
-          <option key={d.code} value={d.code}>
-            {d.name}
-          </option>
-        ))}
+        {divisionList.map((d) =>
+          d.code === prevDivisionCode ? (
+            <option key={d.code} value={d.code} selected>
+              {d.name}
+            </option>
+          ) : (
+            <option key={d.code} value={d.code}>
+              {d.name}
+            </option>
+          )
+        )}
       </S_Select>
       <S_Select id='local' name='district' onChange={handleSelectChange}>
         <option>선택</option>
         {districtList &&
-          districtList.map((d) => (
-            <option key={d.code} value={d.code}>
-              {d.name}
-            </option>
-          ))}
+          districtList.map((d) =>
+            d.code === prevDistrictCode ? (
+              <option key={d.code} value={d.code} selected>
+                {d.name}
+              </option>
+            ) : (
+              <option key={d.code} value={d.code}>
+                {d.name}
+              </option>
+            )
+          )}
       </S_Select>
     </div>
   );

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -99,14 +99,14 @@ function ClubIntro() {
     getClubInfo();
   }, []);
 
-  // console.log(clubInfo);
+  console.log(clubInfo);
 
-  // TODO : profileImage 이미지 잘 뜨는지 확인
+  // TODO : clubImageUrl 이미지 잘 뜨는지 확인
   const {
     clubName,
     content,
     categoryName,
-    profileImage,
+    clubImageUrl,
     local,
     memberCount,
     tagResponseDtos: tags
@@ -146,9 +146,9 @@ function ClubIntro() {
         <Tabmenu tabs={tabs}></Tabmenu>
         <ClubIntroWrapper>
           <div className='profile-img-box'>
-            {/* TODO: img src 추후 profileImage로 변경 */}
+            {/* TODO: img src 추후 clubImageUrl로 변경 */}
             <img
-              src={profileImage}
+              src={clubImageUrl}
               alt='소모임 소개 이미지'
               className='profile-img'
               style={{ width: '100%' }}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,7 +2,9 @@ export interface ClubData {
   // ClubList에 뿌려줄 클럽 데이터 타입 설정
   clubId?: number;
   clubName: string;
-  profileImage?: string;
+  // TODO: default image 설정이 잘 된다면 추후 null 값 들어올 일이 없음
+  // TODO: optional ? 도 삭제해야 함
+  clubImageUrl?: string;
   content: string;
   local: string;
   categoryName: string;
@@ -13,6 +15,7 @@ export interface ClubData {
     tagName: string;
   }[];
   modifiedAt?: string;
+  // TODO: secret의 optional ? 삭제 필요
   secret?: boolean;
 }
 export interface ClubPage {


### PR DESCRIPTION
## 개요
* 요구사항 ID : CLUB-EDIT
* Issue No. : #134 

## 작업 카테고리
- [x] Feature 
- [ ] Update
- [ ] Fix
- [ ] Refactor
- [ ] Test

## 핵심 사항
  + 기존 소모임 정보를 default value 로 화면에 보여주기
  + patch api 요청 로직 작성 

### 수정 사항
* [ClubData 타입의 key name 변경 수정 적용](https://github.com/codestates-seb/seb42_main_018/pull/223/commits/72afef874b62610811d63785de039a7645aca581)
  + profileImage -> ClubImageUrl 로 변경
  + 채리님이 작업하신 ClubList, MainContents, ClubListSetting 컴포의 keyname도 제가 일괄 수정해놨으니 확인 한 번 부탁드려요. 