### PR TITLE
[FE] ✨feat : 소모임 수정 페이지 구현 완료

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "axios": "^1.3.4",
+        "form-data": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.5",
@@ -4955,19 +4956,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -8273,9 +8261,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11621,6 +11609,19 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jsesc": {
@@ -20866,18 +20867,6 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "axobject-query": {
@@ -23311,9 +23300,9 @@
       }
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -25715,6 +25704,18 @@
         "whatwg-url": "^8.5.0",
         "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "jsesc": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "axios": "^1.3.4",
+    "form-data": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.5",

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 import getGlobalState from '../util/authorization/getGlobalState';
+import alertPreparingService from '../util/alertPreparingService';
 import logo from '../assets/logo.svg';
 import search from '../assets/icon_search.svg';
 import mypage from '../assets/icon_mypage.svg';
@@ -50,7 +51,7 @@ function Header() {
       </Link>
       <IconContainer>
         {/* TODO : 클릭시 검색창 모달 열리게 */}
-        <button>
+        <button onClick={alertPreparingService}>
           <img src={search} alt='검색 아이콘' />
         </button>
         <button onClick={() => navigate('/mypage')}>

--- a/client/src/components/LoginChecker.tsx
+++ b/client/src/components/LoginChecker.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { ReactNode } from 'react';
 import getGlobalState from '../util/authorization/getGlobalState';
 
@@ -8,11 +8,14 @@ interface LoginCheckerProps {
 }
 
 function LoginChecker({ children }: LoginCheckerProps) {
-  const navigate = useNavigate();
   const { isLogin } = getGlobalState();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const RETURN_URL_PARAM = 'returnUrl';
 
   useEffect(() => {
-    if (!isLogin) navigate('/login');
+    if (!isLogin)
+      navigate(`/login?${RETURN_URL_PARAM}=${encodeURIComponent(pathname)}`, { replace: true });
   }, [isLogin]);
 
   return isLogin ? <>{children}</> : null;

--- a/client/src/components/MyPage/ClubListSetting.tsx
+++ b/client/src/components/MyPage/ClubListSetting.tsx
@@ -14,7 +14,7 @@ function ClubListSetting() {
           key={el.clubId}
           clubId={el.clubId}
           clubName={el.clubName}
-          clubImageUrl={el.profileImage}
+          clubImage={el.profileImage}
           content={el.content}
           local={el.local}
           categoryName={el.categoryName}

--- a/client/src/components/home/ClubList.tsx
+++ b/client/src/components/home/ClubList.tsx
@@ -47,7 +47,7 @@ const S_Hidden = styled.div`
 function ClubList({
   clubId,
   clubName,
-  clubImageUrl,
+  clubImage,
   content,
   local,
   categoryName,
@@ -56,7 +56,7 @@ function ClubList({
 }: ClubData) {
   return (
     <S_ClubBox>
-      <S_ImgBox img={clubImageUrl} />
+      <S_ImgBox img={clubImage} />
       <Link to={`/club/${clubId}`}>
         <S_ContentsBox>
           <S_TitleBox>

--- a/client/src/components/home/MainContents.tsx
+++ b/client/src/components/home/MainContents.tsx
@@ -76,7 +76,7 @@ function MainContents() {
           key={el.clubId}
           clubId={el.clubId}
           clubName={el.clubName}
-          clubImageUrl={el.profileImage}
+          clubImage={el.profileImage}
           content={el.content}
           local={el.local}
           categoryName={el.categoryName}

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -105,7 +105,10 @@ function CreateClub() {
       return;
     }
 
-    // TODO : localValue에 공백이나 특수문자 있는지 확인하고 alert
+    if (categoryValue.includes(' ')) {
+      alert('소모임 종류의 입력란에 있는 공백을 제거해 주세요.');
+      return;
+    }
 
     const newClubData: CreateClubDataType = {
       ...inputs,
@@ -117,7 +120,6 @@ function CreateClub() {
 
     // console.log(newClubData);
 
-    // TODO: 서버 post 요청 로직 작성
     const POST_URL = `${process.env.REACT_APP_URL}/clubs`;
     const res = await postFetch(POST_URL, newClubData);
     if (res) navigate(res.headers.location);

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -2,6 +2,8 @@ import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { postFetch } from '../../../util/api';
+import getGlobalState from '../../../util/authorization/getGlobalState';
+import LoginChecker from '../../../components/LoginChecker';
 import CreateCategory from './_createCategory';
 import CreateLocal from './_createLocal';
 import CreateTag from './_createTag';
@@ -60,6 +62,7 @@ function CreateClub() {
   const [tags, setTags] = useState<string[]>([]);
   const [categoryValue, setCategoryValue] = useState('');
   const [localValue, setLocalValue] = useState('');
+  const { userInfo } = getGlobalState();
 
   // * textarea 높이 자동 조절 관련
   // const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -120,81 +123,83 @@ function CreateClub() {
 
     // console.log(newClubData);
 
-    const POST_URL = `${process.env.REACT_APP_URL}/clubs`;
+    const POST_URL = `${process.env.REACT_APP_URL}/${userInfo.userId}/clubs`;
     const res = await postFetch(POST_URL, newClubData);
     if (res) navigate(res.headers.location);
   };
 
   return (
-    <S_Container>
-      <S_Title>신규 소모임 만들기</S_Title>
-      <S_FormWrapper>
-        <form onSubmit={onSubmit}>
-          <div>
-            <label htmlFor='clubName'>
-              <S_Label_mg_top>소모임 이름 *</S_Label_mg_top>
-            </label>
-            <S_Input
-              id='clubName'
-              name='clubName'
-              type='text'
-              maxLength={16}
-              value={clubName}
-              onChange={onChange}
-              width='96%'
-            />
-          </div>
-          <div>
-            <label htmlFor='content'>
-              <S_Label_mg_top>소모임 소개글 *</S_Label_mg_top>
-            </label>
-            <S_TextArea
-              id='content'
-              name='content'
-              maxLength={255}
-              placeholder='소모임 소개와 함께 가입조건, 모임장소 및 날짜를 입력해 보세요. (글자수 제한 255자)'
-              value={content}
-              onChange={onChange}
-              // ref={textareaRef}
-            />
-          </div>
-          <CreateCategory inputValue={categoryValue} setInputValue={setCategoryValue} />
-          <CreateLocal inputValue={localValue} setInputValue={setLocalValue} />
-          <CreateTag tags={tags} setTags={setTags} />
-          <fieldset className='isSecret'>
+    <LoginChecker>
+      <S_Container>
+        <S_Title>신규 소모임 만들기</S_Title>
+        <S_FormWrapper>
+          <form onSubmit={onSubmit}>
             <div>
-              <S_Label_mg_top>공개여부 *</S_Label_mg_top>
+              <label htmlFor='clubName'>
+                <S_Label_mg_top>소모임 이름 *</S_Label_mg_top>
+              </label>
+              <S_Input
+                id='clubName'
+                name='clubName'
+                type='text'
+                maxLength={16}
+                value={clubName}
+                onChange={onChange}
+                width='96%'
+              />
             </div>
-            <S_RadioWrapper>
-              <div className='partition'>
-                <S_Input
-                  type='radio'
-                  id='public'
-                  name='isSecret'
-                  value='false'
-                  onChange={onChange}
-                  defaultChecked
-                />
-                <label htmlFor='public'>공개</label>
+            <div>
+              <label htmlFor='content'>
+                <S_Label_mg_top>소모임 소개글 *</S_Label_mg_top>
+              </label>
+              <S_TextArea
+                id='content'
+                name='content'
+                maxLength={255}
+                placeholder='소모임 소개와 함께 가입조건, 모임장소 및 날짜를 입력해 보세요. (글자수 제한 255자)'
+                value={content}
+                onChange={onChange}
+                // ref={textareaRef}
+              />
+            </div>
+            <CreateCategory inputValue={categoryValue} setInputValue={setCategoryValue} />
+            <CreateLocal inputValue={localValue} setInputValue={setLocalValue} />
+            <CreateTag tags={tags} setTags={setTags} />
+            <fieldset className='isSecret'>
+              <div>
+                <S_Label_mg_top>공개여부 *</S_Label_mg_top>
               </div>
-              <div className='partition'>
-                <S_Input
-                  type='radio'
-                  id='private'
-                  name='isSecret'
-                  value='true'
-                  onChange={onChange}
-                />
-                <label htmlFor='private'>비공개</label>
-              </div>
-            </S_RadioWrapper>
-          </fieldset>
-          <div className='submit-btn-box'>
-            <S_Button>소모임 만들기</S_Button>
-          </div>
-        </form>
-      </S_FormWrapper>
-    </S_Container>
+              <S_RadioWrapper>
+                <div className='partition'>
+                  <S_Input
+                    type='radio'
+                    id='public'
+                    name='isSecret'
+                    value='false'
+                    onChange={onChange}
+                    defaultChecked
+                  />
+                  <label htmlFor='public'>공개</label>
+                </div>
+                <div className='partition'>
+                  <S_Input
+                    type='radio'
+                    id='private'
+                    name='isSecret'
+                    value='true'
+                    onChange={onChange}
+                  />
+                  <label htmlFor='private'>비공개</label>
+                </div>
+              </S_RadioWrapper>
+            </fieldset>
+            <div className='submit-btn-box'>
+              <S_Button>소모임 만들기</S_Button>
+            </div>
+          </form>
+        </S_FormWrapper>
+      </S_Container>
+    </LoginChecker>
   );
 }
 

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -8,19 +8,23 @@ import CreateTag from './_createTag';
 import S_Container from '../../../components/UI/S_Container';
 import { S_Input } from '../../../components/UI/S_Input';
 import { S_TextArea } from '../../../components/UI/S_TextArea';
-import { S_Title, S_Label } from '../../../components/UI/S_Text';
+import { S_Title } from '../../../components/UI/S_Text';
+import { S_Label_mg_top } from './EditClub';
 import { S_Button } from '../../../components/UI/S_Button';
 import { EditClubDataType } from './EditClub';
 
 export const S_FormWrapper = styled.div`
-  margin-top: 12px;
+  margin-top: 1.2rem;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
 
   & .isPrivate {
     display: flex;
     justify-content: space-between;
+  }
+
+  & .submit-btn-box {
+    margin-top: 1.2rem;
   }
 `;
 
@@ -125,7 +129,7 @@ function CreateClub() {
         <form onSubmit={onSubmit}>
           <div>
             <label htmlFor='clubName'>
-              <S_Label>소모임 이름 *</S_Label>
+              <S_Label_mg_top>소모임 이름 *</S_Label_mg_top>
             </label>
             <S_Input
               id='clubName'
@@ -139,7 +143,7 @@ function CreateClub() {
           </div>
           <div>
             <label htmlFor='content'>
-              <S_Label>소모임 소개글 *</S_Label>
+              <S_Label_mg_top>소모임 소개글 *</S_Label_mg_top>
             </label>
             <S_TextArea
               id='content'
@@ -156,7 +160,7 @@ function CreateClub() {
           <CreateTag tags={tags} setTags={setTags} />
           <fieldset className='isPrivate'>
             <div>
-              <S_Label>공개여부 *</S_Label>
+              <S_Label_mg_top>공개여부 *</S_Label_mg_top>
             </div>
             <S_RadioWrapper>
               <div className='partition'>
@@ -182,7 +186,9 @@ function CreateClub() {
               </div>
             </S_RadioWrapper>
           </fieldset>
-          <S_Button>소모임 만들기</S_Button>
+          <div className='submit-btn-box'>
+            <S_Button>소모임 만들기</S_Button>
+          </div>
         </form>
       </S_FormWrapper>
     </S_Container>

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -81,7 +81,6 @@ function CreateClub() {
     isSecret: false
   });
   const { clubName, content, isSecret } = inputs;
-  console.log(inputs);
 
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
@@ -105,6 +104,8 @@ function CreateClub() {
       alert('*가 표시된 항목은 필수 입력란입니다.');
       return;
     }
+
+    // TODO : localValue에 공백이나 특수문자 있는지 확인하고 alert
 
     const newClubData: CreateClubDataType = {
       ...inputs,

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -18,7 +18,7 @@ export const S_FormWrapper = styled.div`
   display: flex;
   flex-direction: column;
 
-  & .isPrivate {
+  & .isSecret {
     display: flex;
     justify-content: space-between;
   }
@@ -78,16 +78,16 @@ function CreateClub() {
     content: '',
     local: '',
     categoryName: '',
-    isPrivate: false
+    isSecret: false
   });
-  const { clubName, content, isPrivate } = inputs;
+  const { clubName, content, isSecret } = inputs;
   console.log(inputs);
 
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
-    setInputs({ ...inputs, [name]: name === 'isPrivate' ? value === 'true' : value });
+    setInputs({ ...inputs, [name]: name === 'isSecret' ? value === 'true' : value });
   };
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -111,7 +111,7 @@ function CreateClub() {
       categoryName: categoryValue,
       local: localValue,
       tagName: tags,
-      isPrivate
+      isSecret
     };
 
     // console.log(newClubData);
@@ -158,7 +158,7 @@ function CreateClub() {
           <CreateCategory inputValue={categoryValue} setInputValue={setCategoryValue} />
           <CreateLocal inputValue={localValue} setInputValue={setLocalValue} />
           <CreateTag tags={tags} setTags={setTags} />
-          <fieldset className='isPrivate'>
+          <fieldset className='isSecret'>
             <div>
               <S_Label_mg_top>공개여부 *</S_Label_mg_top>
             </div>
@@ -167,7 +167,7 @@ function CreateClub() {
                 <S_Input
                   type='radio'
                   id='public'
-                  name='isPrivate'
+                  name='isSecret'
                   value='false'
                   onChange={onChange}
                   defaultChecked
@@ -178,7 +178,7 @@ function CreateClub() {
                 <S_Input
                   type='radio'
                   id='private'
-                  name='isPrivate'
+                  name='isSecret'
                   value='true'
                   onChange={onChange}
                 />

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import { getFetch, patchFetch } from '../../../util/api';
 import CreateLocal from './_createLocal';
 import CreateTag from './_createTag';
@@ -8,8 +9,9 @@ import { S_FormWrapper } from './CreateClub';
 import { S_Title, S_Label, S_Description } from '../../../components/UI/S_Text';
 import { S_Input } from '../../../components/UI/S_Input';
 import { S_TextArea } from '../../../components/UI/S_TextArea';
-import { S_Button } from '../../../components/UI/S_Button';
+import { S_Button, S_EditButton } from '../../../components/UI/S_Button';
 import { S_RadioWrapper } from './CreateClub';
+import { S_ImgBox } from '../../mypage/EditProfile';
 import { ClubData } from '../../../types';
 
 export interface EditClubDataType {
@@ -19,6 +21,30 @@ export interface EditClubDataType {
   tagName?: string[];
   isPrivate: boolean;
 }
+
+interface ImgFileType {
+  lastModified: number;
+  lastModifiedDate?: object;
+  name: string;
+  size: number;
+  type: string;
+  webkitRelativePath: string;
+}
+
+export const S_Label_mg_top = styled(S_Label)`
+  margin-top: 1rem;
+`;
+
+const S_ImageBox = styled(S_ImgBox)`
+  & > img {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 10px;
+    margin-right: 10px;
+    background-color: var(--gray200);
+  }
+`;
 
 function EditClub() {
   const navigate = useNavigate();
@@ -33,7 +59,7 @@ function EditClub() {
     tagName: [],
     isPrivate: false
   });
-  const { categoryName, local: prevLocal, secret } = clubInfo || {};
+  const { categoryName, clubImageUrl, local: prevLocal, secret } = clubInfo || {};
   const { clubName, content } = inputs || {};
 
   useEffect(() => {
@@ -65,8 +91,6 @@ function EditClub() {
     getClubInfo();
   }, []);
 
-  // !TODO: profileImage patch 요청 어떻게 보낼지 BE와 방식 논의 필요
-
   const [tags, setTags] = useState<string[]>([]);
   const [localValue, setLocalValue] = useState('');
 
@@ -77,18 +101,46 @@ function EditClub() {
     setInputs({ ...inputs, [name]: name === 'isPrivate' ? value === 'true' : value });
   };
 
+  // !TODO: profileImage patch 요청 어떻게 보낼지 BE와 방식 논의 필요
+  // 버튼 클릭시 파일첨부(input#file) 실행시켜주는 함수. 못생긴 파일첨부 input은 안녕!
+  const uploadImg = () => {
+    const inputname = document.getElementById('uploadImg');
+    inputname?.click();
+  };
+
+  // 파일로 가져온 이미지 미리보기
+  const [imgFile, setImgFile] = useState(clubImageUrl);
+  // const [imgFile, setImgFile] = useState<ImgFileType>();
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    console.log(file);
+
+    if (file) {
+      const reader = new FileReader();
+      reader.addEventListener('load', () => {
+        setImgFile(reader.result as string);
+      });
+      // setImgFile(file);
+      reader.readAsDataURL(file);
+    }
+  };
+
+  console.log(typeof imgFile); // string
+
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
     const updateData = {
       ...inputs,
       tagName: tags,
-      local: localValue
+      local: localValue,
+      // * 이미지 파일 string으로 추가
+      clubImageUrl: imgFile
     };
 
-    // console.log(updateData);
-    const res = await patchFetch(URL, updateData);
-    if (res) navigate(`/club/${clubId}`);
+    console.log(updateData);
+    // const res = await patchFetch(URL, updateData);
+    // if (res) navigate(`/club/${clubId}`);
   };
 
   return (
@@ -98,7 +150,7 @@ function EditClub() {
         <form onSubmit={onSubmit}>
           <div>
             <label htmlFor='clubName'>
-              <S_Label>소모임 이름 *</S_Label>
+              <S_Label_mg_top>소모임 이름 *</S_Label_mg_top>
             </label>
             <S_Input
               id='clubName'
@@ -112,7 +164,7 @@ function EditClub() {
           </div>
           <div>
             <label htmlFor='content'>
-              <S_Label>소모임 소개글 *</S_Label>
+              <S_Label_mg_top>소모임 소개글 *</S_Label_mg_top>
             </label>
             <S_TextArea
               id='content'
@@ -127,7 +179,7 @@ function EditClub() {
 
           <div>
             <label htmlFor='categoryName'>
-              <S_Label>카테고리</S_Label>
+              <S_Label_mg_top>카테고리</S_Label_mg_top>
             </label>
             <S_Description>소모임 종류는 처음 모임을 만든 다음에는 변경할 수 없어요.</S_Description>
             <S_Input
@@ -143,11 +195,28 @@ function EditClub() {
           <CreateTag tags={tags} setTags={setTags} />
 
           {/* //TODO: 사진 등록 영역 */}
-          <S_Label>사진 등록</S_Label>
+          <div>
+            <S_Label_mg_top>사진 등록</S_Label_mg_top>
+            <S_ImageBox>
+              <img id='previewimg' src={imgFile ? imgFile : clubImageUrl} alt='소모임 소개 사진' />
+              <label htmlFor='file'>
+                <S_EditButton type='button' onClick={uploadImg}>
+                  변경
+                </S_EditButton>
+                <input
+                  id='uploadImg'
+                  type='file'
+                  accept='image/*'
+                  onChange={handleFileUpload}
+                  hidden
+                />
+              </label>
+            </S_ImageBox>
+          </div>
 
           <fieldset className='isPrivate'>
             <div>
-              <S_Label>공개여부 *</S_Label>
+              <S_Label_mg_top>공개여부 *</S_Label_mg_top>
             </div>
             <S_RadioWrapper>
               <div className='partition'>
@@ -194,7 +263,9 @@ function EditClub() {
               </div>
             </S_RadioWrapper>
           </fieldset>
-          <S_Button>정보수정 완료</S_Button>
+          <div className='submit-btn-box'>
+            <S_Button>정보수정 완료</S_Button>
+          </div>
         </form>
       </S_FormWrapper>
     </S_Container>

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -225,7 +225,7 @@ function EditClub() {
             </S_ImageBox>
           </div>
 
-          <fieldset className='isPrivate'>
+          <fieldset className='isSecret'>
             <div>
               <S_Label_mg_top>공개여부 *</S_Label_mg_top>
             </div>
@@ -235,7 +235,7 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isPrivate'
+                    name='isSecret'
                     value='true'
                     onChange={onChange}
                   />
@@ -243,7 +243,7 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isPrivate'
+                    name='isSecret'
                     value='true'
                     onChange={onChange}
                     defaultChecked
@@ -256,7 +256,7 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isPrivate'
+                    name='isSecret'
                     value='true'
                     onChange={onChange}
                     defaultChecked
@@ -265,7 +265,7 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isPrivate'
+                    name='isSecret'
                     value='true'
                     onChange={onChange}
                   />

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -134,7 +134,7 @@ function EditClub() {
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (clubImage) {
+    if (clubImageFile) {
       const formData: FormData = new FormData();
       formData.append('clubName', clubName);
       formData.append('content', content);

--- a/client/src/pages/club/club/_createCategory.tsx
+++ b/client/src/pages/club/club/_createCategory.tsx
@@ -16,8 +16,11 @@ export interface CreateCategoryProps {
 interface CategoryListDataType {
   categoryName: string;
 }
+
 function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
   const [categories, setCategories] = useState<string[]>();
+  const [isFocused, setIsFocused] = useState(false);
+
   useEffect(() => {
     const GET_URL = `${process.env.REACT_APP_URL}/categories`;
     const getCategoryList = async () => {
@@ -63,6 +66,16 @@ function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
     }
   };
 
+  const handleInputFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleInputBlur = () => {
+    setTimeout(() => {
+      setIsFocused(false);
+    }, 150);
+  };
+
   return (
     <div style={{ marginTop: '0.8rem' }}>
       <>
@@ -77,8 +90,11 @@ function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
           value={inputValue}
           onKeyUp={handleKeyUp}
           onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
           ref={input}
           width='96%'
+          autoComplete='off'
         />
       </>
       {hasText && (
@@ -86,6 +102,7 @@ function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
           options={options}
           handleComboBox={handleDropDownClick}
           currentOption={currentOption}
+          isFocused={isFocused}
         />
       )}
     </div>

--- a/client/src/pages/club/club/_createCategory.tsx
+++ b/client/src/pages/club/club/_createCategory.tsx
@@ -64,7 +64,7 @@ function CreateCategory({ inputValue, setInputValue }: CreateCategoryProps) {
   };
 
   return (
-    <div>
+    <div style={{ marginTop: '0.8rem' }}>
       <>
         <label htmlFor='categoryName'>
           <S_Label>어떤 소모임을 만드실 건가요? *</S_Label>

--- a/client/src/pages/club/club/_createLocal.tsx
+++ b/client/src/pages/club/club/_createLocal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { DIVISIONS_DATA } from './divisions';
 import { CreateCategoryProps } from './_createCategory';
-// import { S_Label } from '../../../components/UI/S_Text';
 import { S_Label_mg_top } from './EditClub';
 import { S_Select } from '../../../components/UI/S_Select';
 

--- a/client/src/pages/club/club/_createLocal.tsx
+++ b/client/src/pages/club/club/_createLocal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { DIVISIONS_DATA } from './divisions';
 import { CreateCategoryProps } from './_createCategory';
-import { S_Label } from '../../../components/UI/S_Text';
+// import { S_Label } from '../../../components/UI/S_Text';
+import { S_Label_mg_top } from './EditClub';
 import { S_Select } from '../../../components/UI/S_Select';
 
 interface DistrictType {
@@ -83,7 +84,7 @@ function CreateLocal({ inputValue, setInputValue, prevData }: CreateLocalProps) 
   return (
     <div>
       <label htmlFor='local'>
-        <S_Label>지역 *</S_Label>
+        <S_Label_mg_top>지역 *</S_Label_mg_top>
       </label>
       <S_Select id='local' name='division' onChange={handleSelectChange}>
         <option>선택</option>

--- a/client/src/pages/club/club/_createTag.tsx
+++ b/client/src/pages/club/club/_createTag.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { S_Label, S_Description } from '../../../components/UI/S_Text';
+import { S_Description } from '../../../components/UI/S_Text';
+import { S_Label_mg_top } from './EditClub';
 import { S_Input } from '../../../components/UI/S_Input';
 import { S_Tag } from '../../../components/UI/S_Tag';
 
@@ -41,7 +42,7 @@ function CreateTag({ tags, setTags }: CreateTagProps) {
   return (
     <div>
       <label htmlFor='tagName'>
-        <S_Label>태그</S_Label>
+        <S_Label_mg_top>태그</S_Label_mg_top>
       </label>
       <S_Description>최대 3개까지 입력할 수 있습니다.</S_Description>
       <S_Input

--- a/client/src/pages/club/club/_dropDown.tsx
+++ b/client/src/pages/club/club/_dropDown.tsx
@@ -4,7 +4,6 @@ import { HandleDropDownClick } from './_createCategory';
 const S_DropDownContainer = styled.ul`
   background-color: var(--gray100);
 
-  /* //TODO: input이 focus를 잃으면 dropdown이 안 보이게 코드 수정 */
   width: 100%;
   display: block;
   margin-left: auto;
@@ -38,25 +37,23 @@ interface DropDownProps {
   currentOption: number;
   options?: string[];
   handleComboBox: HandleDropDownClick;
+  isFocused: boolean;
 }
 
-function DropDown({ currentOption, options, handleComboBox }: DropDownProps) {
-  return (
+function DropDown({ currentOption, options, handleComboBox, isFocused }: DropDownProps) {
+  return isFocused && options && options.length > 0 ? (
     <S_DropDownContainer>
-      {options?.map((item, idx) => {
+      {options.map((item, idx) => {
         return (
-          <li
-            role='presentation'
-            key={idx}
-            className={idx === currentOption ? 'selected' : ''}
-            onClick={() => handleComboBox(item)}
-          >
-            {item}
+          <li key={idx} className={idx === currentOption ? 'selected' : ''}>
+            <button type='button' onClick={() => handleComboBox(item)}>
+              {item}
+            </button>
           </li>
         );
       })}
     </S_DropDownContainer>
-  );
+  ) : null;
 }
 
 export default DropDown;

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -76,19 +76,15 @@ function ClubIntro() {
   const navigate = useNavigate();
   const { isLogin, userInfo } = getGlobalState();
   const [clubInfo, setClubInfo] = useState<ClubData>();
-
-  console.log(userInfo);
+  // @param isApplied : 가입신청을 이미 한 번 했으면 true, 아직 안했으면 false
+  const [isApplied, setIsApplied] = useState(false);
 
   // TODO : 리더에게만 뱃지와 프로필 설정 버튼이 보이는지 확인
   const myClub = userInfo.userClubResponses?.find((club) => club.clubId === Number(id));
   const isLeader = myClub?.clubRole === 'LEADER';
-  const isMember = myClub?.clubRole !== null; // null: 가입신청 후 승인/거절 결정되기 전 pending 상태
+  const isMember = myClub && myClub.clubRole !== null; // null: 가입신청 후 승인/거절 결정되기 전 pending 상태
   // console.log(myClub);
   // console.log(isMember);
-
-  // ! TODO : 가입신청 후 모달만 꺼지기 때문에 clubRole === null 바로 확인할 수가 없음
-  // 가입신청 성공을 확인하는 상태를 하나 더 만들어서 관리하든지
-  // useEffect로 get 요청을 보내서 최신 유저 정보를 한 번 더 확인해야 할지?
 
   useEffect(() => {
     const GET_URL = `${process.env.REACT_APP_URL}/clubs/${id}`;
@@ -97,8 +93,11 @@ function ClubIntro() {
       setClubInfo(res.data);
     };
     getClubInfo();
+
+    if (myClub && myClub.clubRole === null) setIsApplied(true);
   }, []);
 
+  console.log(userInfo);
   console.log(clubInfo);
 
   // TODO : clubImageUrl 이미지 잘 뜨는지 확인
@@ -130,9 +129,12 @@ function ClubIntro() {
   const { pathname } = useLocation();
   const RETURN_URL_PARAM = 'returnUrl';
 
-  // !! TODO : 이미 가입 신청을 완료한 소모임인지 확인 필요
-  // 가입신청 완료한 상태에서 또 클릭하면 사용자에게 알람
   const handleJoinRequest = () => {
+    if (isApplied) {
+      alert('이미 가입신청을 하셨어요. 마이페이지에서 가입신청 승인 현황을 확인할 수 있습니다.');
+      return;
+    }
+
     if (isLogin) {
       handleModal();
     } else {
@@ -146,7 +148,6 @@ function ClubIntro() {
         <Tabmenu tabs={tabs}></Tabmenu>
         <ClubIntroWrapper>
           <div className='profile-img-box'>
-            {/* TODO: img src 추후 clubImageUrl로 변경 */}
             <img
               src={clubImageUrl}
               alt='소모임 소개 이미지'
@@ -186,7 +187,6 @@ function ClubIntro() {
           <div className='club-content-box'>
             <p style={{ whiteSpace: 'pre-line' }}>{content}</p>
           </div>
-          {/* //! 공개 소모임 중에서 소모임 멤버가 아닌 유저에게만 렌더링 */}
           {!isMember && (
             <div className='join-btn-box'>
               <S_Button addStyle={{ width: '48%' }} onClick={handleJoinRequest}>
@@ -207,7 +207,12 @@ function ClubIntro() {
           )}
         </ClubIntroWrapper>
 
-        <ClubJoinModal handleModal={handleModal} showModal={showModal} />
+        <ClubJoinModal
+          handleModal={handleModal}
+          showModal={showModal}
+          // isApplied={isApplied}
+          setIsApplied={setIsApplied}
+        />
       </S_Container>
     </>
   );

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -15,8 +15,9 @@ import ClubJoinModal from './_clubJoinModal';
 import leaderBadgeIcon from '../../../assets/icon_leader-badge.svg';
 
 const ClubIntroWrapper = styled.div`
-  /* position: relative; */
+  position: relative;
   margin-top: 30px;
+  min-height: 88vh;
 
   & > .profile-img-box {
     margin: 0 -20px;
@@ -26,13 +27,10 @@ const ClubIntroWrapper = styled.div`
     align-items: center;
     background-color: var(--gray100);
   }
-  & .profile-img {
-    max-width: 100%;
-    max-height: 100%;
-  }
 
   & > .club-info-box {
-    margin-top: 1.5rem;
+    margin-top: 1.2rem;
+    padding-bottom: 0.4rem;
     display: flex;
     border-bottom: 1px solid var(--gray200);
   }
@@ -40,13 +38,9 @@ const ClubIntroWrapper = styled.div`
     flex: 3;
   }
   & .club-title-box {
-    margin-bottom: 5px;
     display: flex;
     align-items: center;
-    & .club-title {
-      margin: 0;
-    }
-    & > img {
+    & > .leader-badge-icon {
       margin-left: 6px;
       transform: scale(1.2);
     }
@@ -57,20 +51,21 @@ const ClubIntroWrapper = styled.div`
   }
 
   & > .club-content-box {
-    margin-top: 12px;
+    margin-top: 1rem;
+    margin-bottom: calc(50px + 1rem);
   }
 
   & > .join-btn-box {
-    /* position: absolute;
+    position: absolute;
     bottom: 0;
     right: 0;
-    left: 0; */
-    margin-top: 1.5rem;
+    left: 0;
 
     display: flex;
     justify-content: space-between;
   }
 `;
+
 function ClubIntro() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -159,7 +154,9 @@ function ClubIntro() {
             <div className='club-info-area'>
               <div className='club-title-box'>
                 <S_Title className='club-title'>{clubName}</S_Title>
-                {isLeader && <img src={leaderBadgeIcon} alt='소모임장 아이콘' />}
+                {isLeader && (
+                  <img src={leaderBadgeIcon} alt='소모임장 아이콘' className='leader-badge-icon' />
+                )}
               </div>
               <div className='club-detail-box'>
                 <S_Description>

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -33,6 +33,10 @@ const ClubIntroWrapper = styled.div`
     padding-bottom: 0.4rem;
     display: flex;
     border-bottom: 1px solid var(--gray200);
+
+    .profile-img {
+      /* background-size: contain; */
+    }
   }
   & .club-info-area {
     flex: 3;
@@ -95,12 +99,11 @@ function ClubIntro() {
   console.log(userInfo);
   console.log(clubInfo);
 
-  // TODO : clubImageUrl 이미지 잘 뜨는지 확인
   const {
     clubName,
     content,
     categoryName,
-    clubImageUrl,
+    clubImage,
     local,
     memberCount,
     tagResponseDtos: tags
@@ -143,12 +146,7 @@ function ClubIntro() {
         <Tabmenu tabs={tabs}></Tabmenu>
         <ClubIntroWrapper>
           <div className='profile-img-box'>
-            <img
-              src={clubImageUrl}
-              alt='소모임 소개 이미지'
-              className='profile-img'
-              style={{ width: '100%' }}
-            />
+            <img src={clubImage} alt='소모임 소개 이미지' className='profile-img' />
           </div>
           <div className='club-info-box'>
             <div className='club-info-area'>
@@ -207,7 +205,6 @@ function ClubIntro() {
         <ClubJoinModal
           handleModal={handleModal}
           showModal={showModal}
-          // isApplied={isApplied}
           setIsApplied={setIsApplied}
         />
       </S_Container>

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -80,9 +80,9 @@ function ClubIntro() {
   console.log(userInfo);
 
   // TODO : 리더에게만 뱃지와 프로필 설정 버튼이 보이는지 확인
-  const myClub = userInfo.userClubResponses?.find((club) => club.userClubId === Number(id));
+  const myClub = userInfo.userClubResponses?.find((club) => club.clubId === Number(id));
   const isLeader = myClub?.clubRole === 'LEADER';
-  const isMember = myClub && myClub.clubRole !== null; // null: 가입신청 후 승인/거절 결정되기 전 pending 상태
+  const isMember = myClub?.clubRole !== null; // null: 가입신청 후 승인/거절 결정되기 전 pending 상태
   // console.log(myClub);
   // console.log(isMember);
 

--- a/client/src/pages/club/intro/_clubJoinModal.tsx
+++ b/client/src/pages/club/intro/_clubJoinModal.tsx
@@ -33,7 +33,6 @@ const S_ButtonBox = styled.div`
 interface RegisterModalProps {
   showModal: boolean;
   handleModal: () => void;
-  // isApplied: boolean;
   setIsApplied: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/client/src/pages/club/intro/_clubJoinModal.tsx
+++ b/client/src/pages/club/intro/_clubJoinModal.tsx
@@ -33,9 +33,11 @@ const S_ButtonBox = styled.div`
 interface RegisterModalProps {
   showModal: boolean;
   handleModal: () => void;
+  // isApplied: boolean;
+  setIsApplied: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-function ClubJoinModal({ showModal, handleModal }: RegisterModalProps) {
+function ClubJoinModal({ showModal, handleModal, setIsApplied }: RegisterModalProps) {
   const { userInfo, tokens } = getGlobalState();
   const { id: clubId } = useParams();
   const [content, setContent] = useState('');
@@ -55,6 +57,7 @@ function ClubJoinModal({ showModal, handleModal }: RegisterModalProps) {
     // TODO : 모달이 떠있는 채로 alert를 띄우면 모바일에서 겹쳐 보이는지 확인
     if (res) {
       setContent('');
+      setIsApplied(true);
       handleModal();
       alert('가입신청을 완료했어요. 마이페이지에서 가입신청 승인 현황을 확인할 수 있습니다.');
     }

--- a/client/src/pages/mypage/EditProfile.tsx
+++ b/client/src/pages/mypage/EditProfile.tsx
@@ -29,7 +29,7 @@ const S_EditBox = styled.div`
   }
 `;
 
-const S_ImgBox = styled.div`
+export const S_ImgBox = styled.div`
   // 유저 프로필이미지 설정
   display: flex;
   align-items: center;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -7,11 +7,16 @@ export interface RootState {
 }
 
 export interface UserClubResponsesType {
-  userClubId: number;
+  clubId: number;
+  // * clubRole: null - 가입신청을 하였으나 아직 처리(승인 또는 거절)가 되지 않은 pending 상태일 때의 값
   clubRole: null | 'MEMBER' | 'MANAGER' | 'LEADER';
-  player: boolean;
+  // * ACTIVE: 활동중 | BLACKED: 추방 | QUIT: 탈퇴
+  clubMemberStatus: null | 'MEMBER ACTIVE' | 'MEMBER BLACKED' | 'MEMBER QUIT';
+  // TODO: joinStatus 항목 안 보이는데 BE에 확인 필요
+  joinStatus?: null | 'PENDING' | 'CONFIRMED' | 'REFUSED' | 'BANISHED';
   level: null | string;
   playCount: number;
+  player: boolean;
   winCount: number;
   winRate: number;
 }
@@ -19,7 +24,7 @@ export interface UserInfoType {
   userId: number | undefined;
   email: string;
   nickName: string;
-  userStatus: string;
+  userStatus: '' | 'USER_NEW' | 'USER_ACTIVE' | 'USER_SLEEP' | 'USER_QUIT';
   profileImage: string;
   userClubResponses?: UserClubResponsesType[];
 }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,9 +2,8 @@ export interface ClubData {
   // ClubList에 뿌려줄 클럽 데이터 타입 설정
   clubId?: number;
   clubName: string;
-  // TODO: default image 설정이 잘 된다면 추후 null 값 들어올 일이 없음
-  // TODO: optional ? 도 삭제해야 함
-  clubImageUrl?: string;
+  // TODO: optional ? 삭제해야 함
+  clubImage?: string;
   content: string;
   local: string;
   categoryName: string;

--- a/client/src/util/api.ts
+++ b/client/src/util/api.ts
@@ -27,16 +27,22 @@ export const postFetch = async <T>(url: string, newData: T, tokens?: JwtTokensTy
   }
 };
 
-export const patchFetch = async <T>(url: string, updateData: T, tokens?: JwtTokensType) => {
+export const patchFetch = async <T>(
+  url: string,
+  updateData: T,
+  tokens?: JwtTokensType,
+  contentType?: string
+) => {
   try {
     const res = await axios.patch(url, updateData, {
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': contentType ? contentType : 'application/json',
         withCredentials: true,
         Authorization: tokens?.accessToken,
         Refresh: tokens?.refreshToken
       }
     });
+
     if (res.status === 200) return res;
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## 개요
* 요구사항 ID : CLUB-EDIT, CLUB-DETAIL, CLUB-JOIN
* Issue No. : close #134 

## 작업 카테고리
- [x] Feature 
- [x] Update
- [ ] Fix
- [ ] Refactor
- [ ] Test

## 핵심 사항
* 소모임 수정 페이지 사진 등록 섹션 추가 및 patch api 테스트 완료
* 소모임 소개 페이지 일부 css 코드 수정 (가입신청 및 문의하기 버튼 영역 하단 고정)
<img width="814" alt="스크린샷 2023-03-26 오전 12 34 08" src="https://user-images.githubusercontent.com/115610668/227727198-e791acaa-bdda-4083-8c97-8ba190d220c2.png">
<img width="814" alt="스크린샷 2023-03-26 오전 12 34 55" src="https://user-images.githubusercontent.com/115610668/227727206-b13865d0-767a-41b2-a87c-a6aef8d3e6d2.png">



### 수정 내용 (fix의 경우)
* 변경 부분: 소모임 소개 페이지 (ClubIntro.tsx) 
* 변경 이유:
  + 클럽 정보 관련 데이터 필드명 변경 반영 (clubUserID -> clubId, clubImageUrl -> clubImage, isPrivate -> isSecret)
  + 가입신청을 이미 했는지 여부를 확인하기 위한 isApplied 상태 변수 추가 
  + 가입신청 및 문의하기 버튼 영역 하단에 고정 

