### PR TITLE
[FE] 🐛fix : 소모임 생성시 비공개 설정 안되던 부분 해결

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "axios": "^1.3.4",
+        "fetch-jsonp": "^1.2.3",
         "form-data": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7922,6 +7923,11 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fetch-jsonp": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.2.3.tgz",
+      "integrity": "sha512-C13k1o7R9JTN1wmhKkrW5bU/00LwixXnkufQUR6Rbf4KCS0i8mycQaovt4WVbHnA2NKgi7Ryp9Whpy/CGcij6Q=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -23064,6 +23070,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fetch-jsonp": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.2.3.tgz",
+      "integrity": "sha512-C13k1o7R9JTN1wmhKkrW5bU/00LwixXnkufQUR6Rbf4KCS0i8mycQaovt4WVbHnA2NKgi7Ryp9Whpy/CGcij6Q=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "axios": "^1.3.4",
+    "fetch-jsonp": "^1.2.3",
     "form-data": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/components/home/home/MainContents.tsx
+++ b/client/src/components/home/home/MainContents.tsx
@@ -77,7 +77,7 @@ function MainContents() {
       {/* TODO : 선택한 카테고리랑 일치하는 카테고리의 리스트만 필터 */}
       {clubs.map(
         (el) =>
-          el.secret === false && (
+          el.clubPrivateStatus === 'PUBLIC' && (
             <ClubList
               key={el.clubId}
               clubId={el.clubId}

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -19,7 +19,7 @@ export const S_FormWrapper = styled.div`
   display: flex;
   flex-direction: column;
 
-  & .isSecret {
+  & .clubPrivateStatus {
     display: flex;
     justify-content: space-between;
   }
@@ -80,15 +80,15 @@ function CreateClub() {
     content: '',
     local: '',
     categoryName: '',
-    isSecret: false
+    clubPrivateStatus: 'PUBLIC'
   });
-  const { clubName, content, isSecret } = inputs;
+  const { clubName, content, clubPrivateStatus } = inputs;
 
   const onChange = (
     e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
-    setInputs({ ...inputs, [name]: name === 'isSecret' ? value === 'true' : value });
+    setInputs({ ...inputs, [name]: value });
   };
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -117,7 +117,7 @@ function CreateClub() {
       categoryName: categoryValue,
       local: localValue,
       tagList: tags,
-      isSecret
+      clubPrivateStatus
     };
 
     // console.log(newClubData);
@@ -165,7 +165,7 @@ function CreateClub() {
             <CreateCategory inputValue={categoryValue} setInputValue={setCategoryValue} />
             <CreateLocal inputValue={localValue} setInputValue={setLocalValue} />
             <CreateTag tags={tags} setTags={setTags} />
-            <fieldset className='isSecret'>
+            <fieldset className='clubPrivateStatus'>
               <div>
                 <S_Label_mg_top>공개여부 *</S_Label_mg_top>
               </div>
@@ -174,8 +174,8 @@ function CreateClub() {
                   <S_Input
                     type='radio'
                     id='public'
-                    name='isSecret'
-                    value='false'
+                    name='clubPrivateStatus'
+                    value='PUBLIC'
                     onChange={onChange}
                     defaultChecked
                   />
@@ -185,8 +185,8 @@ function CreateClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isSecret'
-                    value='true'
+                    name='clubPrivateStatus'
+                    value='SECRET'
                     onChange={onChange}
                   />
                   <label htmlFor='private'>비공개</label>

--- a/client/src/pages/club/club/CreateClub.tsx
+++ b/client/src/pages/club/club/CreateClub.tsx
@@ -100,7 +100,8 @@ function CreateClub() {
       !content ||
       !categoryValue ||
       !localValue ||
-      localValue.includes('undefined')
+      localValue.includes('undefined') ||
+      !clubPrivateStatus
     ) {
       // TODO: 추후 모달로 변경
       alert('*가 표시된 항목은 필수 입력란입니다.');
@@ -120,10 +121,7 @@ function CreateClub() {
       clubPrivateStatus
     };
 
-    // console.log(newClubData);
-
     const POST_URL = `${process.env.REACT_APP_URL}/${userInfo.userId}/clubs`;
-    // console.log(tokens);
     const res = await postFetch(POST_URL, newClubData, tokens, true);
     if (res) navigate(res.headers.location);
   };

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -20,7 +20,7 @@ export interface EditClubDataType {
   content: string;
   local: string;
   tagList?: string[];
-  isSecret: boolean;
+  clubPrivateStatus?: 'PUBLIC' | 'SECRET';
 }
 
 export interface ImageFileType {
@@ -54,21 +54,22 @@ function EditClub() {
   const URL = `${process.env.REACT_APP_URL}/clubs/${clubId}`;
 
   const [clubInfo, setClubInfo] = useState<ClubData>();
-  const [inputs, setInputs] = useState<EditClubDataType>({
-    clubName: '',
-    content: '',
-    local: '',
-    tagList: [],
-    isSecret: false
-  });
   const {
     categoryName,
     clubImage,
     local: prevLocal,
     tagList: prevTagList,
-    secret
+    clubPrivateStatus: prevClubPrivateStatus
   } = clubInfo || {};
-  const { clubName, content, isSecret } = inputs || {};
+
+  const [inputs, setInputs] = useState<EditClubDataType>({
+    clubName: '',
+    content: '',
+    local: '',
+    tagList: [],
+    clubPrivateStatus: prevClubPrivateStatus
+  });
+  const { clubName, content, clubPrivateStatus } = inputs || {};
 
   useEffect(() => {
     const getClubInfo = async () => {
@@ -81,7 +82,7 @@ function EditClub() {
       setTags(prevTagList);
       setLocalValue(prevLocal);
 
-      if (clubInfo) {
+      if (clubInfo && clubPrivateStatus) {
         setInputs({
           ...inputs,
           clubName: clubInfo.clubName,
@@ -90,7 +91,7 @@ function EditClub() {
           tagList: prevTagList,
 
           // !BUG : 비공개 소모임(secret: true) 생성해도 서버에서 전부 secret: false 로 처리되고 있음
-          isSecret: clubInfo.secret || false
+          clubPrivateStatus: clubInfo.clubPrivateStatus
         });
       }
     };
@@ -155,7 +156,7 @@ function EditClub() {
     formData.append('content', content);
     formData.append('local', localData);
     formData.append('tagList', tags);
-    formData.append('isSecret', isSecret);
+    formData.append('clubPrivateStatus', clubPrivateStatus);
 
     if (clubImageFile) formData.append('clubImage', clubImageFile);
     else formData.append('clubImage', null);
@@ -254,7 +255,7 @@ function EditClub() {
             </div>
             <S_RadioWrapper>
               <div className='partition'>
-                {secret ? (
+                {clubPrivateStatus === 'PUBLIC' ? (
                   <S_Input
                     type='radio'
                     id='private'
@@ -275,7 +276,7 @@ function EditClub() {
                 <label htmlFor='public'>공개</label>
               </div>
               <div className='partition'>
-                {secret ? (
+                {clubPrivateStatus === 'SECRET' ? (
                   <S_Input
                     type='radio'
                     id='private'

--- a/client/src/pages/club/club/EditClub.tsx
+++ b/client/src/pages/club/club/EditClub.tsx
@@ -65,8 +65,8 @@ function EditClub() {
   const [inputs, setInputs] = useState<EditClubDataType>({
     clubName: '',
     content: '',
-    local: '',
-    tagList: [],
+    local: prevLocal || '',
+    tagList: prevTagList,
     clubPrivateStatus: prevClubPrivateStatus
   });
   const { clubName, content, clubPrivateStatus } = inputs || {};
@@ -82,15 +82,13 @@ function EditClub() {
       setTags(prevTagList);
       setLocalValue(prevLocal);
 
-      if (clubInfo && clubPrivateStatus) {
+      if (clubInfo) {
         setInputs({
           ...inputs,
           clubName: clubInfo.clubName,
           content: clubInfo.content,
           local: prevLocal,
           tagList: prevTagList,
-
-          // !BUG : 비공개 소모임(secret: true) 생성해도 서버에서 전부 secret: false 로 처리되고 있음
           clubPrivateStatus: clubInfo.clubPrivateStatus
         });
       }
@@ -105,7 +103,7 @@ function EditClub() {
     e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
-    setInputs({ ...inputs, [name]: name === 'isSecret' ? value === 'true' : value });
+    setInputs({ ...inputs, [name]: value });
   };
 
   // 버튼 클릭시 파일첨부(input#file) 실행시켜주는 함수
@@ -162,9 +160,9 @@ function EditClub() {
     else formData.append('clubImage', null);
 
     // ! BE 확인을 위해 console.log 잠시 풀어둠
-    console.log(formData); // 빈 객체로 보임
-    const formDataEntries = formData as unknown as Array<[string, unknown]>;
-    console.log(Array.from(formDataEntries)); // formData에 담긴 key-value pair 확인 가능
+    // console.log(formData); // 빈 객체로 보임
+    // const formDataEntries = formData as unknown as Array<[string, unknown]>;
+    // console.log(Array.from(formDataEntries)); // formData에 담긴 key-value pair 확인 가능
 
     // ! any 외에 다른 방법은 정녕 없는가
     // ERROR MESSAGE: TS2339: Property '_boundary' does not exist on type 'FormData'.
@@ -249,7 +247,7 @@ function EditClub() {
             </S_ImageBox>
           </div>
 
-          <fieldset className='isSecret'>
+          <fieldset className='clubPrivateStatus'>
             <div>
               <S_Label_mg_top>공개여부 *</S_Label_mg_top>
             </div>
@@ -259,18 +257,18 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isSecret'
-                    value='true'
+                    name='clubPrivateStatus'
+                    value='PUBLIC'
                     onChange={onChange}
+                    defaultChecked
                   />
                 ) : (
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isSecret'
-                    value='true'
+                    name='clubPrivateStatus'
+                    value='PUBLIC'
                     onChange={onChange}
-                    defaultChecked
                   />
                 )}
                 <label htmlFor='public'>공개</label>
@@ -280,18 +278,18 @@ function EditClub() {
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isSecret'
-                    value='true'
+                    name='clubPrivateStatus'
+                    value='SECRET'
                     onChange={onChange}
-                    defaultChecked
                   />
                 ) : (
                   <S_Input
                     type='radio'
                     id='private'
-                    name='isSecret'
-                    value='true'
+                    name='clubPrivateStatus'
+                    value='SECRET'
                     onChange={onChange}
+                    defaultChecked
                   />
                 )}
                 <label htmlFor='private'>비공개</label>

--- a/client/src/pages/club/intro/ClubIntro.tsx
+++ b/client/src/pages/club/intro/ClubIntro.tsx
@@ -13,7 +13,6 @@ import { S_Title, S_Description } from '../../../components/UI/S_Text';
 import { S_Tag } from '../../../components/UI/S_Tag';
 import { S_TagWrapper } from '../club/_createTag';
 import ClubJoinModal from './_clubJoinModal';
-import { userInitialState } from '../../../store/store';
 import leaderBadgeIcon from '../../../assets/icon_leader-badge.svg';
 import defaultClubImg from '../../../assets/default_Img.svg';
 
@@ -44,7 +43,7 @@ const ClubIntroWrapper = styled.div`
     margin-bottom: 4px;
     display: flex;
     align-items: center;
-    & > .leader-badge-icon {
+    & .leader-badge-icon {
       margin-left: 6px;
       transform: scale(1.2);
     }
@@ -165,10 +164,16 @@ function ClubIntro() {
           <div className='club-info-box'>
             <div className='club-info-area'>
               <div className='club-title-box'>
-                <S_Title className='club-title'>{clubName}</S_Title>
-                {isLeader && (
-                  <img src={leaderBadgeIcon} alt='소모임장 아이콘' className='leader-badge-icon' />
-                )}
+                <S_Title className='club-title'>
+                  {clubName}
+                  {isLeader && (
+                    <img
+                      src={leaderBadgeIcon}
+                      alt='소모임장 아이콘'
+                      className='leader-badge-icon'
+                    />
+                  )}
+                </S_Title>
               </div>
               <div className='club-detail-box'>
                 {memberCount && (

--- a/client/src/pages/mypage/EditProfile.tsx
+++ b/client/src/pages/mypage/EditProfile.tsx
@@ -138,7 +138,9 @@ function EditProfile() {
                 alt='프로필사진'
               />
               <label htmlFor='file'>
-                <S_EditButton onClick={uploadImg}>변경</S_EditButton>
+                <S_EditButton onClick={uploadImg} type='button'>
+                  변경
+                </S_EditButton>
                 <input
                   id='uploadImg'
                   type='file'

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -10,7 +10,7 @@ export interface ClubData {
   memberCount?: number;
   tagList: string[];
   modifiedAt?: string;
-  secret?: boolean;
+  clubPrivateStatus?: 'PUBLIC' | 'SECRET';
 }
 export interface ClubPage {
   // 페이지네이션 정보 타입 설정


### PR DESCRIPTION
## 개요
* 요구사항 ID : CLUB-CREATE, CLUB-EDIT
* Issue No. : 

## 작업 카테고리
- [ ] Feature 
- [ ] Update
- [x] Fix
- [ ] Refactor
- [ ] Test

## 수정 사항
* 소모임 생성시 비공개로 설정해도 서버에서 전부 공개로 데이터가 지정되던 현상 해결
* 공개/비공개 여부를 기존 boolean으로 보내던 것에서 데이터 타입을 string으로 변경
```  
clubPrivateStatus: 'PUBLIC' | 'SECRET'
```
* 프로필 수정 시 '변경' 버튼 누르면 제출되던 현상 해결 : button type='button' 지정