### PR TITLE
[FE]🐛 fix: 경기수정 전적 두 팀 내 동일 멤버있으면 저장불가하게 구현

### DIFF
--- a/client/src/pages/club/match/EditMatch.tsx
+++ b/client/src/pages/club/match/EditMatch.tsx
@@ -255,6 +255,22 @@ function EditMatch() {
     setTeamList([...copiedTeamList]);
   };
 
+  const checkTeamInRecords = (): boolean => {
+    let result = true;
+    records.forEach((record) => {
+      const firstTeam = teamList.filter((el) => el.teamNumber === record.firstTeamNumber);
+      const secondTeam = teamList.filter((el) => el.teamNumber === record.secondTeamNumber);
+
+      firstTeam[0].membersIds.forEach((el) => {
+        if (secondTeam[0].membersIds.includes(el)) {
+          alert('두 팀에 동일한 멤버가 존재합니다.');
+          result = false;
+        }
+      });
+    });
+    return result;
+  };
+
   useEffect(() => {
     if (!userInfo.userClubResponses.map((el) => el.clubId).includes(Number(id))) {
       alert('권한이 없습니다.');
@@ -483,6 +499,9 @@ function EditMatch() {
               return;
             }
             updateRecord();
+            if (!checkTeamInRecords()) {
+              return;
+            }
             setIsOpenConfirm(true);
           }}
         >

--- a/client/src/pages/club/match/EditMatch.tsx
+++ b/client/src/pages/club/match/EditMatch.tsx
@@ -112,6 +112,7 @@ function EditMatch() {
   const deleteNameTagFromTeam = (idx: number, memberIdx: number) => {
     const copied = [...teamList];
     const deletedMember = copied[idx].members.splice(memberIdx, 1);
+    copied[idx].membersIds.splice(memberIdx, 1);
     setCandidateList([...candidateList, deletedMember[0]]);
     setTeamList(copied);
   };
@@ -260,6 +261,9 @@ function EditMatch() {
     records.forEach((record) => {
       const firstTeam = teamList.filter((el) => el.teamNumber === record.firstTeamNumber);
       const secondTeam = teamList.filter((el) => el.teamNumber === record.secondTeamNumber);
+
+      console.log(firstTeam);
+      console.log(secondTeam);
 
       firstTeam[0].membersIds.forEach((el) => {
         if (secondTeam[0].membersIds.includes(el)) {

--- a/client/src/pages/club/match/EditMatch.tsx
+++ b/client/src/pages/club/match/EditMatch.tsx
@@ -262,9 +262,6 @@ function EditMatch() {
       const firstTeam = teamList.filter((el) => el.teamNumber === record.firstTeamNumber);
       const secondTeam = teamList.filter((el) => el.teamNumber === record.secondTeamNumber);
 
-      console.log(firstTeam);
-      console.log(secondTeam);
-
       firstTeam[0].membersIds.forEach((el) => {
         if (secondTeam[0].membersIds.includes(el)) {
           alert('두 팀에 동일한 멤버가 존재합니다.');


### PR DESCRIPTION
## 개요
* 요구사항 ID : 
* Issue No. : 

## 작업 카테고리
- [ ] Feature 
- [ ] Update
- [x] Fix
- [ ] Refactor
- [ ] Test

## 핵심 사항
* 전적 - 한 경기 두 팀 내에 동일 멤버가 있으면 저장이 불가하게 validation check 구현
